### PR TITLE
Force create WiFi directories

### DIFF
--- a/init.b2g.rc
+++ b/init.b2g.rc
@@ -52,6 +52,11 @@ on post-fs-data
     mkdir /data/misc/dhcp-6.8.2 0770 dhcp dhcp
     chown dhcp dhcp /data/misc/dhcp-6.8.2
 
+    # Create the directories used by the Wireless subsystem
+    mkdir /data/vendor/wifi 0771 wifi wifi
+    mkdir /data/vendor/wifi/wpa 0770 wifi wifi
+    mkdir /data/vendor/wifi/wpa/sockets 0770 wifi wifi
+
 on property:init.svc.wpa_supplicant=stopped
     stop dhcpcd
 


### PR DESCRIPTION
Some device does that in the vendor partition, which we might not have
access to. Let's use this for now.